### PR TITLE
feat: fix rule table page crash

### DIFF
--- a/web/src/SiteListPage.js
+++ b/web/src/SiteListPage.js
@@ -44,6 +44,8 @@ class SiteListPage extends BaseListPage {
       domain: "door.casdoor.com",
       otherDomains: [],
       needRedirect: false,
+      disableVerbose: false,
+      rules: [],
       challenges: [],
       host: "",
       port: 8000,

--- a/web/src/components/RuleTable.js
+++ b/web/src/components/RuleTable.js
@@ -26,6 +26,10 @@ class RuleTable extends React.Component {
     this.state = {
       classes: props,
     };
+    if (this.props.rules === null) {
+      // rerender
+      this.props.onUpdateRules([]);
+    }
   }
 
   updateTable(table) {
@@ -122,7 +126,7 @@ class RuleTable extends React.Component {
         <Row style={{marginTop: "20px"}} >
           <Col span={24}>
             {
-              this.renderTable(this.props.rules.map((item, index) => {
+              this.props.rules === null ? null : this.renderTable(this.props.rules.map((item, index) => {
                 const values = item.split("/");
                 return {owner: values[0], name: values[1]};
               }))


### PR DESCRIPTION
After #55, when the site has not set `rules` field, the frontend would break down.

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/44eacc94-b60c-4236-8cf3-042fbc47bd1f">
