### PR TITLE
feat: Introduce runtime configuration for the frontend via `config.js` to allow dynamic updates without rebuilding the Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,30 @@ CasWAF uses Casdoor to manage members. So you need to create an organization and
 - **Docker Compose**: Use the provided `docker-compose.yml` for quick local setup
 - **Manual Installation**: Build and run from source
 
+### Runtime Configuration (Recommended)
+
+You can configure CasWAF to use your own Casdoor instance **without rebuilding the Docker image** by mounting a custom `config.js` file:
+
+```bash
+# Create config.custom.js with your Casdoor settings
+docker run -d -p 8080:8080 \
+  -v $(pwd)/config.custom.js:/web/build/config.js:ro \
+  -v $(pwd)/conf/app.conf:/conf/app.conf:ro \
+  casbin/caswaf:latest
+```
+
+Example `config.custom.js`:
+```javascript
+window.appConfig = {
+  serverUrl: "https://your-casdoor.com",
+  clientId: "your-client-id",
+  appName: "caswaf",
+  organizationName: "your-org",
+  redirectPath: "/callback",
+};
+```
+
+
 ### Necessary configuration
 
 #### Get the code

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can configure CasWAF to use your own Casdoor instance **without rebuilding t
 
 ```bash
 # Create config.custom.js with your Casdoor settings
-docker run -d -p 8080:8080 \
+docker run -d -p 17000:17000 \
   -v $(pwd)/config.custom.js:/web/build/config.js:ro \
   -v $(pwd)/conf/app.conf:/conf/app.conf:ro \
   casbin/caswaf:latest

--- a/web/public/config.js
+++ b/web/public/config.js
@@ -12,18 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Load configuration from runtime config.js file (mounted at /web/build/config.js)
-// This allows configuration to be changed without rebuilding the Docker image
-export const AuthConfig = window.appConfig || {
-  // Fallback defaults if config.js is not loaded
-  serverUrl: "https://door.casdoor.com",
-  clientId: "af6b5aa958822fb9dc33",
-  appName: "app-casibase",
-  organizationName: "casbin",
-  redirectPath: "/callback",
+// Runtime configuration for CasWAF frontend
+// This file can be mounted/replaced at runtime without rebuilding the Docker image
+// Mount location: /web/build/config.js
+window.appConfig = {
+    serverUrl: "https://door.casdoor.com",
+    clientId: "af6b5aa958822fb9dc33",
+    appName: "app-casibase",
+    organizationName: "casbin",
+    redirectPath: "/callback",
 };
-
-export const IsDemoMode = false;
-
-export const ForceLanguage = "";
-export const DefaultLanguage = "en";

--- a/web/public/config.js
+++ b/web/public/config.js
@@ -1,4 +1,4 @@
-// Copyright 2023 The casbin Authors. All Rights Reserved.
+// Copyright 2026 The casbin Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -25,6 +25,8 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>CasWAF</title>
+    <!-- Load runtime configuration before React app -->
+    <script src="%PUBLIC_URL%/config.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
fix: https://github.com/casbin/caswaf/issues/158