### PR TITLE
feat: fix dockerfile missing package (tzdata)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL MAINTAINER="https://caswaf.org/"
 
 COPY --from=BACK /go/src/caswaf/ ./
 COPY --from=BACK /usr/bin/wait-for-it ./
-RUN mkdir -p web/build && apk add --no-cache bash coreutils
+RUN mkdir -p web/build && apk add --no-cache bash coreutils tzdata
 COPY --from=FRONT /web/build /web/build
 ENTRYPOINT ["./wait-for-it", "db:3306", "--", "./server"]
 


### PR DESCRIPTION
Alpine Linux (used in the Dockerfile) doesn't include timezone data by default, which causes the error:

```bash
 the request url is  /api/add-rule
2026/02/16 00:54:06.483 [C] [panic.go:884]  Handler crashed with error unknown time zone Asia/Singapore
2026/02/16 00:54:06.483 [C] [panic.go:884]  /usr/local/go/src/runtime/panic.go:884
2026/02/16 00:54:06.483 [C] [panic.go:884]  /go/src/caswaf/util/time.go:22
2026/02/16 00:54:06.483 [C] [panic.go:884]  /go/src/caswaf/controllers/rule.go:91
2026/02/16 00:54:06.483 [C] [panic.go:884]  /usr/local/go/src/reflect/value.go:586
2026/02/16 00:54:06.483 [C] [panic.go:884]  /usr/local/go/src/reflect/value.go:370
2026/02/16 00:54:06.483 [C] [panic.go:884]  /go/pkg/mod/github.com/beego/beego@v1.12.12/router.go:897
2026/02/16 00:54:06.483 [C] [panic.go:884]  /usr/local/go/src/net/http/server.go:2936
2026/02/16 00:54:06.483 [C] [panic.go:884]  /usr/local/go/src/net/http/server.go:1995
2026/02/16 00:54:06.483 [C] [panic.go:884]  /usr/local/go/src/runtime/asm_amd64.s:1598
```

To fix that, we have to add the `tzdata` package installer to the Dockerfile.