### PR TITLE
feature: Fetch JWT certificates dynamically from a JWKS endpoint, fix: database-agnostic SQL helpers for timestamp formatting

### DIFF
--- a/casdoor/init.go
+++ b/casdoor/init.go
@@ -16,6 +16,11 @@ package casdoor
 
 import (
 	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 
 	"github.com/beego/beego"
 	"github.com/casdoor/casdoor-go-sdk/casdoorsdk"
@@ -24,11 +29,65 @@ import (
 //go:embed token_jwt_key.pem
 var JwtPublicKey string
 
+type JWKSResponse struct {
+	Keys []JWK `json:"keys"`
+}
+
+type JWK struct {
+	X5C []string `json:"x5c"` // X.509 certificate chain
+}
+
 func InitCasdoorConfig() {
 	casdoorEndpoint := beego.AppConfig.String("casdoorEndpoint")
 	clientId := beego.AppConfig.String("clientId")
 	clientSecret := beego.AppConfig.String("clientSecret")
 	casdoorOrganization := beego.AppConfig.String("casdoorOrganization")
 	casdoorApplication := beego.AppConfig.String("casdoorApplication")
-	casdoorsdk.InitConfig(casdoorEndpoint, clientId, clientSecret, JwtPublicKey, casdoorOrganization, casdoorApplication)
+
+	// Try to fetch certificate from Casdoor's standard JWKS endpoint
+	jwtPublicKey := JwtPublicKey // default to embedded certificate
+
+	jwksUrl := fmt.Sprintf("%s/.well-known/jwks", strings.TrimRight(casdoorEndpoint, "/"))
+	beego.Info("Fetching JWT certificate from JWKS: ", jwksUrl)
+
+	if cert, err := fetchCertificateFromJWKS(jwksUrl); err == nil && cert != "" {
+		jwtPublicKey = cert
+		beego.Info("Successfully loaded JWT certificate from JWKS endpoint")
+	} else {
+		beego.Warn("Failed to fetch certificate from JWKS (", err, "), using embedded certificate")
+	}
+
+	casdoorsdk.InitConfig(casdoorEndpoint, clientId, clientSecret, jwtPublicKey, casdoorOrganization, casdoorApplication)
+}
+
+func fetchCertificateFromJWKS(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var jwks JWKSResponse
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return "", err
+	}
+
+	if len(jwks.Keys) == 0 || len(jwks.Keys[0].X5C) == 0 {
+		return "", fmt.Errorf("no certificates in JWKS")
+	}
+
+	// Extract the first certificate and format as PEM
+	certData := jwks.Keys[0].X5C[0]
+	pemCert := fmt.Sprintf("-----BEGIN CERTIFICATE-----\n%s\n-----END CERTIFICATE-----\n", certData)
+
+	return pemCert, nil
 }

--- a/object/record.go
+++ b/object/record.go
@@ -107,7 +107,7 @@ type DataCount struct {
 func unixTimestampExpr(col string) string {
 	switch ormer.driverName {
 	case "postgres":
-		return "EXTRACT(EPOCH FROM " + col + "::timestamp)"
+		return "CAST(EXTRACT(EPOCH FROM " + col + "::timestamp) AS bigint)"
 	case "mssql":
 		return "DATEDIFF(SECOND, '1970-01-01', CONVERT(datetime, " + col + "))"
 	case "sqlite":

--- a/object/record.go
+++ b/object/record.go
@@ -165,29 +165,46 @@ func GetMetricsOverTime(startAt time.Time, timeType string) (*[]DataCount, error
 // timeType2Format returns a DB-appropriate strftime/date-format pattern for
 // the given time granularity. The format is chosen to match the active driver.
 func timeType2Format(timeType string) string {
-	isPostgresOrMssql := ormer.driverName == "postgres" || ormer.driverName == "mssql"
+	isPostgres := ormer.driverName == "postgres"
+	isMssql := ormer.driverName == "mssql"
+
 	switch timeType {
 	case "hour":
-		if isPostgresOrMssql {
+		if isPostgres {
+			// Postgres uses to_char with its own format tokens.
 			return "YYYY-MM-DD HH24"
+		}
+		if isMssql {
+			// SQL Server FORMAT() uses .NET-style format strings.
+			return "yyyy-MM-dd HH"
 		}
 		if ormer.driverName == "sqlite" {
 			return "%Y-%m-%d %H"
 		}
 		return "%Y-%m-%d %H"
 	case "day":
-		if isPostgresOrMssql {
+		if isPostgres {
 			return "YYYY-MM-DD"
+		}
+		if isMssql {
+			return "yyyy-MM-dd"
 		}
 		return "%Y-%m-%d"
 	case "month":
-		if isPostgresOrMssql {
+		if isPostgres {
 			return "YYYY-MM"
+		}
+		if isMssql {
+			return "yyyy-MM"
 		}
 		return "%Y-%m"
 	}
-	if isPostgresOrMssql {
+
+	if isPostgres {
 		return "YYYY-MM-DD HH24"
+	}
+	if isMssql {
+		return "yyyy-MM-dd HH"
 	}
 	return "%Y-%m-%d %H"
 }


### PR DESCRIPTION
This pull request improves database compatibility for time-based metrics queries and enhances Casdoor JWT certificate handling. The main changes include adding database-agnostic SQL helpers for timestamp formatting and conversion, and updating Casdoor initialization to fetch JWT certificates dynamically from a JWKS endpoint.

**Database compatibility improvements:**

* Added `unixTimestampExpr` and `dateFormatExpr` helper functions in `object/record.go` to generate SQL expressions for converting and formatting timestamps, supporting MySQL, PostgreSQL, MSSQL, and SQLite. Metrics queries now use these helpers for cross-database compatibility. [[1]](diffhunk://#diff-6aba339fe57cb637537c17af400ebb214f8fcec89af2a0886bb54e47afc9745cR105-R138) [[2]](diffhunk://#diff-6aba339fe57cb637537c17af400ebb214f8fcec89af2a0886bb54e47afc9745cL122-R154)
* Updated `timeType2Format` to return driver-specific date/time format strings, ensuring correct grouping for metrics over time across different databases.

**Casdoor JWT certificate handling:**

* Modified `InitCasdoorConfig` in `casdoor/init.go` to fetch the JWT public certificate from Casdoor's JWKS endpoint at runtime, falling back to the embedded certificate if fetching fails. This improves security and flexibility when validating JWTs. Added supporting types and the `fetchCertificateFromJWKS` helper function. [[1]](diffhunk://#diff-aa5d39da504fd7c4b5b52b7d07f619225150c5c965ccc18b8e26dbe898c8bf51R19-R23) [[2]](diffhunk://#diff-aa5d39da504fd7c4b5b52b7d07f619225150c5c965ccc18b8e26dbe898c8bf51R32-R92)